### PR TITLE
ci: Download jom and NASM from OpenSSL-hosted mirror

### DIFF
--- a/.github/ci-deps.json
+++ b/.github/ci-deps.json
@@ -1,0 +1,5 @@
+{
+  "jom-1.1.7.exe": "8435dbf96eb9ee65395d46d04dc3af2ff6b2618aefbc7964eeede9be669e8bd6",
+  "nasm-3.01-installer-x64.exe": "7881e9febc8b6558581041019b7890f109bef0694d93ed82c9589794c7b5a600",
+  "nasm-3.01-installer-x86.exe": "2e3041dd2abe36cb7e9938057c3cf090dd2eac42d3280957359f87c4d83b9ed0"
+}

--- a/.github/workflows/os-zoo.yml
+++ b/.github/workflows/os-zoo.yml
@@ -151,10 +151,14 @@ jobs:
       run: git submodule update --init --depth 1 fuzz/corpora
     - name: install nasm
       run: |
-        choco install nasm
+        Invoke-WebRequest -Uri "https://openssl-library.org/nasm-3.01-installer-x64.exe" -OutFile nasm-installer.exe
+        Start-Process -FilePath .\nasm-installer.exe -ArgumentList '/S' -Wait
         "C:\Program Files\NASM" | Out-File -FilePath "$env:GITHUB_PATH" -Append
     - name: install jom
-      run:  choco install jom
+      run: |
+        mkdir C:\jom
+        Invoke-WebRequest -Uri "https://openssl-library.org/jom-1.1.7.exe" -OutFile C:\jom\jom.exe
+        "C:\jom" | Out-File -FilePath "$env:GITHUB_PATH" -Append
     - name: prepare the build directory
       run: mkdir _build
     - name: config

--- a/.github/workflows/os-zoo.yml
+++ b/.github/workflows/os-zoo.yml
@@ -151,13 +151,20 @@ jobs:
       run: git submodule update --init --depth 1 fuzz/corpora
     - name: install nasm
       run: |
-        Invoke-WebRequest -Uri "https://openssl-library.org/nasm-3.01-installer-x64.exe" -OutFile nasm-installer.exe
-        Start-Process -FilePath .\nasm-installer.exe -ArgumentList '/S' -Wait
+        $installer = "nasm-3.01-installer-x64.exe"
+        Invoke-WebRequest -Uri "https://openssl-library.org/ci-deps/$installer" -OutFile $installer
+        $expected = (Get-Content "$env:GITHUB_WORKSPACE\.github\ci-deps.json" -Raw | ConvertFrom-Json).$installer
+        $actual = (Get-FileHash $installer -Algorithm SHA256).Hash
+        if ($actual -ne $expected) { throw "SHA256 mismatch for $installer (expected $expected, got $actual)" }
+        Start-Process -FilePath ".\$installer" -ArgumentList '/S' -Wait
         "C:\Program Files\NASM" | Out-File -FilePath "$env:GITHUB_PATH" -Append
     - name: install jom
       run: |
         mkdir C:\jom
-        Invoke-WebRequest -Uri "https://openssl-library.org/jom-1.1.7.exe" -OutFile C:\jom\jom.exe
+        Invoke-WebRequest -Uri "https://openssl-library.org/ci-deps/jom-1.1.7.exe" -OutFile C:\jom\jom.exe
+        $expected = (Get-Content "$env:GITHUB_WORKSPACE\.github\ci-deps.json" -Raw | ConvertFrom-Json).'jom-1.1.7.exe'
+        $actual = (Get-FileHash C:\jom\jom.exe -Algorithm SHA256).Hash
+        if ($actual -ne $expected) { throw "SHA256 mismatch for jom.exe (expected $expected, got $actual)" }
         "C:\jom" | Out-File -FilePath "$env:GITHUB_PATH" -Append
     - name: prepare the build directory
       run: mkdir _build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -39,10 +39,14 @@ jobs:
       run: git submodule update --init --depth 1 fuzz/corpora
     - name: install nasm
       run: |
-        choco install nasm ${{ matrix.platform.arch == 'x86' && '--x86' || '' }}
+        Invoke-WebRequest -Uri "https://openssl-library.org/nasm-3.01-installer-${{ matrix.platform.arch == 'x86' && 'x86' || 'x64' }}.exe" -OutFile nasm-installer.exe
+        Start-Process -FilePath .\nasm-installer.exe -ArgumentList '/S' -Wait
         "C:\Program Files${{ matrix.platform.arch == 'x86' && ' (x86)' || '' }}\NASM" | Out-File -FilePath "$env:GITHUB_PATH" -Append
     - name: install jom
-      run: choco install jom
+      run: |
+        mkdir C:\jom
+        Invoke-WebRequest -Uri "https://openssl-library.org/jom-1.1.7.exe" -OutFile C:\jom\jom.exe
+        "C:\jom" | Out-File -FilePath "$env:GITHUB_PATH" -Append
     - name: prepare the build directory
       run: mkdir _build
     - name: config
@@ -117,7 +121,10 @@ jobs:
     - name: prepare the build directory
       run: mkdir _build
     - name: install jom
-      run:  choco install jom
+      run: |
+        mkdir C:\jom
+        Invoke-WebRequest -Uri "https://openssl-library.org/jom-1.1.7.exe" -OutFile C:\jom\jom.exe
+        "C:\jom" | Out-File -FilePath "$env:GITHUB_PATH" -Append
     - name: config
       working-directory: _build
       shell: cmd
@@ -160,7 +167,10 @@ jobs:
     - name: prepare the build directory
       run: mkdir _build
     - name: install jom
-      run:  choco install jom
+      run: |
+        mkdir C:\jom
+        Invoke-WebRequest -Uri "https://openssl-library.org/jom-1.1.7.exe" -OutFile C:\jom\jom.exe
+        "C:\jom" | Out-File -FilePath "$env:GITHUB_PATH" -Append
     - name: config
       working-directory: _build
       shell: cmd

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -38,14 +38,37 @@ jobs:
     - name: checkout fuzz/corpora submodule
       run: git submodule update --init --depth 1 fuzz/corpora
     - name: install nasm
+      if: github.repository == 'openssl/openssl'
       run: |
-        Invoke-WebRequest -Uri "https://openssl-library.org/nasm-3.01-installer-${{ matrix.platform.arch == 'x86' && 'x86' || 'x64' }}.exe" -OutFile nasm-installer.exe
-        Start-Process -FilePath .\nasm-installer.exe -ArgumentList '/S' -Wait
+        $installer = "nasm-3.01-installer-${{ matrix.platform.arch == 'x86' && 'x86' || 'x64' }}.exe"
+        Invoke-WebRequest -Uri "https://openssl-library.org/ci-deps/$installer" -OutFile $installer
+        $expected = (Get-Content "$env:GITHUB_WORKSPACE\.github\ci-deps.json" -Raw | ConvertFrom-Json).$installer
+        $actual = (Get-FileHash $installer -Algorithm SHA256).Hash
+        if ($actual -ne $expected) { throw "SHA256 mismatch for $installer (expected $expected, got $actual)" }
+        Start-Process -FilePath ".\$installer" -ArgumentList '/S' -Wait
+        "C:\Program Files${{ matrix.platform.arch == 'x86' && ' (x86)' || '' }}\NASM" | Out-File -FilePath "$env:GITHUB_PATH" -Append
+    - name: install nasm (forks)
+      if: github.repository != 'openssl/openssl'
+      run: |
+        $installer = "nasm-3.01-installer-${{ matrix.platform.arch == 'x86' && 'x86' || 'x64' }}.exe"
+        Invoke-WebRequest -Uri "https://www.nasm.us/pub/nasm/releasebuilds/3.01/win${{ matrix.platform.arch == 'x86' && '32' || '64' }}/$installer" -OutFile $installer
+        Start-Process -FilePath ".\$installer" -ArgumentList '/S' -Wait
         "C:\Program Files${{ matrix.platform.arch == 'x86' && ' (x86)' || '' }}\NASM" | Out-File -FilePath "$env:GITHUB_PATH" -Append
     - name: install jom
+      if: github.repository == 'openssl/openssl'
       run: |
         mkdir C:\jom
-        Invoke-WebRequest -Uri "https://openssl-library.org/jom-1.1.7.exe" -OutFile C:\jom\jom.exe
+        Invoke-WebRequest -Uri "https://openssl-library.org/ci-deps/jom-1.1.7.exe" -OutFile C:\jom\jom.exe
+        $expected = (Get-Content "$env:GITHUB_WORKSPACE\.github\ci-deps.json" -Raw | ConvertFrom-Json).'jom-1.1.7.exe'
+        $actual = (Get-FileHash C:\jom\jom.exe -Algorithm SHA256).Hash
+        if ($actual -ne $expected) { throw "SHA256 mismatch for jom.exe (expected $expected, got $actual)" }
+        "C:\jom" | Out-File -FilePath "$env:GITHUB_PATH" -Append
+    - name: install jom (forks)
+      if: github.repository != 'openssl/openssl'
+      run: |
+        mkdir C:\jom
+        Invoke-WebRequest -Uri "https://download.qt.io/official_releases/jom/jom_1_1_7.zip" -OutFile C:\jom\jom.zip
+        Expand-Archive -Path C:\jom\jom.zip -DestinationPath C:\jom
         "C:\jom" | Out-File -FilePath "$env:GITHUB_PATH" -Append
     - name: prepare the build directory
       run: mkdir _build
@@ -121,9 +144,20 @@ jobs:
     - name: prepare the build directory
       run: mkdir _build
     - name: install jom
+      if: github.repository == 'openssl/openssl'
       run: |
         mkdir C:\jom
-        Invoke-WebRequest -Uri "https://openssl-library.org/jom-1.1.7.exe" -OutFile C:\jom\jom.exe
+        Invoke-WebRequest -Uri "https://openssl-library.org/ci-deps/jom-1.1.7.exe" -OutFile C:\jom\jom.exe
+        $expected = (Get-Content "$env:GITHUB_WORKSPACE\.github\ci-deps.json" -Raw | ConvertFrom-Json).'jom-1.1.7.exe'
+        $actual = (Get-FileHash C:\jom\jom.exe -Algorithm SHA256).Hash
+        if ($actual -ne $expected) { throw "SHA256 mismatch for jom.exe (expected $expected, got $actual)" }
+        "C:\jom" | Out-File -FilePath "$env:GITHUB_PATH" -Append
+    - name: install jom (forks)
+      if: github.repository != 'openssl/openssl'
+      run: |
+        mkdir C:\jom
+        Invoke-WebRequest -Uri "https://download.qt.io/official_releases/jom/jom_1_1_7.zip" -OutFile C:\jom\jom.zip
+        Expand-Archive -Path C:\jom\jom.zip -DestinationPath C:\jom
         "C:\jom" | Out-File -FilePath "$env:GITHUB_PATH" -Append
     - name: config
       working-directory: _build
@@ -167,9 +201,20 @@ jobs:
     - name: prepare the build directory
       run: mkdir _build
     - name: install jom
+      if: github.repository == 'openssl/openssl'
       run: |
         mkdir C:\jom
-        Invoke-WebRequest -Uri "https://openssl-library.org/jom-1.1.7.exe" -OutFile C:\jom\jom.exe
+        Invoke-WebRequest -Uri "https://openssl-library.org/ci-deps/jom-1.1.7.exe" -OutFile C:\jom\jom.exe
+        $expected = (Get-Content "$env:GITHUB_WORKSPACE\.github\ci-deps.json" -Raw | ConvertFrom-Json).'jom-1.1.7.exe'
+        $actual = (Get-FileHash C:\jom\jom.exe -Algorithm SHA256).Hash
+        if ($actual -ne $expected) { throw "SHA256 mismatch for jom.exe (expected $expected, got $actual)" }
+        "C:\jom" | Out-File -FilePath "$env:GITHUB_PATH" -Append
+    - name: install jom (forks)
+      if: github.repository != 'openssl/openssl'
+      run: |
+        mkdir C:\jom
+        Invoke-WebRequest -Uri "https://download.qt.io/official_releases/jom/jom_1_1_7.zip" -OutFile C:\jom\jom.zip
+        Expand-Archive -Path C:\jom\jom.zip -DestinationPath C:\jom
         "C:\jom" | Out-File -FilePath "$env:GITHUB_PATH" -Append
     - name: config
       working-directory: _build

--- a/.github/workflows/windows_comp.yml
+++ b/.github/workflows/windows_comp.yml
@@ -30,10 +30,14 @@ jobs:
       run: git submodule update --init --depth 1 fuzz/corpora
     - name: install nasm
       run: |
-        choco install nasm
+        Invoke-WebRequest -Uri "https://openssl-library.org/nasm-3.01-installer-x64.exe" -OutFile nasm-installer.exe
+        Start-Process -FilePath .\nasm-installer.exe -ArgumentList '/S' -Wait
         "C:\Program Files\NASM" | Out-File -FilePath "$env:GITHUB_PATH" -Append
     - name: install jom
-      run:  choco install jom
+      run: |
+        mkdir C:\jom
+        Invoke-WebRequest -Uri "https://openssl-library.org/jom-1.1.7.exe" -OutFile C:\jom\jom.exe
+        "C:\jom" | Out-File -FilePath "$env:GITHUB_PATH" -Append
     - name: prepare the build directory
       run: mkdir _build
     - name: Get zstd
@@ -95,10 +99,14 @@ jobs:
       run: git submodule update --init --depth 1 fuzz/corpora
     - name: install nasm
       run: |
-        choco install nasm
+        Invoke-WebRequest -Uri "https://openssl-library.org/nasm-3.01-installer-x64.exe" -OutFile nasm-installer.exe
+        Start-Process -FilePath .\nasm-installer.exe -ArgumentList '/S' -Wait
         "C:\Program Files\NASM" | Out-File -FilePath "$env:GITHUB_PATH" -Append
     - name: install jom
-      run:  choco install jom
+      run: |
+        mkdir C:\jom
+        Invoke-WebRequest -Uri "https://openssl-library.org/jom-1.1.7.exe" -OutFile C:\jom\jom.exe
+        "C:\jom" | Out-File -FilePath "$env:GITHUB_PATH" -Append
     - name: prepare the build directory
       run: mkdir _build
     - name: Get brotli

--- a/.github/workflows/windows_comp.yml
+++ b/.github/workflows/windows_comp.yml
@@ -29,14 +29,37 @@ jobs:
     - name: checkout fuzz/corpora submodule
       run: git submodule update --init --depth 1 fuzz/corpora
     - name: install nasm
+      if: github.repository == 'openssl/openssl'
       run: |
-        Invoke-WebRequest -Uri "https://openssl-library.org/nasm-3.01-installer-x64.exe" -OutFile nasm-installer.exe
-        Start-Process -FilePath .\nasm-installer.exe -ArgumentList '/S' -Wait
+        $installer = "nasm-3.01-installer-x64.exe"
+        Invoke-WebRequest -Uri "https://openssl-library.org/ci-deps/$installer" -OutFile $installer
+        $expected = (Get-Content "$env:GITHUB_WORKSPACE\.github\ci-deps.json" -Raw | ConvertFrom-Json).$installer
+        $actual = (Get-FileHash $installer -Algorithm SHA256).Hash
+        if ($actual -ne $expected) { throw "SHA256 mismatch for $installer (expected $expected, got $actual)" }
+        Start-Process -FilePath ".\$installer" -ArgumentList '/S' -Wait
+        "C:\Program Files\NASM" | Out-File -FilePath "$env:GITHUB_PATH" -Append
+    - name: install nasm (forks)
+      if: github.repository != 'openssl/openssl'
+      run: |
+        $installer = "nasm-3.01-installer-x64.exe"
+        Invoke-WebRequest -Uri "https://www.nasm.us/pub/nasm/releasebuilds/3.01/win64/$installer" -OutFile $installer
+        Start-Process -FilePath ".\$installer" -ArgumentList '/S' -Wait
         "C:\Program Files\NASM" | Out-File -FilePath "$env:GITHUB_PATH" -Append
     - name: install jom
+      if: github.repository == 'openssl/openssl'
       run: |
         mkdir C:\jom
-        Invoke-WebRequest -Uri "https://openssl-library.org/jom-1.1.7.exe" -OutFile C:\jom\jom.exe
+        Invoke-WebRequest -Uri "https://openssl-library.org/ci-deps/jom-1.1.7.exe" -OutFile C:\jom\jom.exe
+        $expected = (Get-Content "$env:GITHUB_WORKSPACE\.github\ci-deps.json" -Raw | ConvertFrom-Json).'jom-1.1.7.exe'
+        $actual = (Get-FileHash C:\jom\jom.exe -Algorithm SHA256).Hash
+        if ($actual -ne $expected) { throw "SHA256 mismatch for jom.exe (expected $expected, got $actual)" }
+        "C:\jom" | Out-File -FilePath "$env:GITHUB_PATH" -Append
+    - name: install jom (forks)
+      if: github.repository != 'openssl/openssl'
+      run: |
+        mkdir C:\jom
+        Invoke-WebRequest -Uri "https://download.qt.io/official_releases/jom/jom_1_1_7.zip" -OutFile C:\jom\jom.zip
+        Expand-Archive -Path C:\jom\jom.zip -DestinationPath C:\jom
         "C:\jom" | Out-File -FilePath "$env:GITHUB_PATH" -Append
     - name: prepare the build directory
       run: mkdir _build
@@ -98,14 +121,37 @@ jobs:
     - name: checkout fuzz/corpora submodule
       run: git submodule update --init --depth 1 fuzz/corpora
     - name: install nasm
+      if: github.repository == 'openssl/openssl'
       run: |
-        Invoke-WebRequest -Uri "https://openssl-library.org/nasm-3.01-installer-x64.exe" -OutFile nasm-installer.exe
-        Start-Process -FilePath .\nasm-installer.exe -ArgumentList '/S' -Wait
+        $installer = "nasm-3.01-installer-x64.exe"
+        Invoke-WebRequest -Uri "https://openssl-library.org/ci-deps/$installer" -OutFile $installer
+        $expected = (Get-Content "$env:GITHUB_WORKSPACE\.github\ci-deps.json" -Raw | ConvertFrom-Json).$installer
+        $actual = (Get-FileHash $installer -Algorithm SHA256).Hash
+        if ($actual -ne $expected) { throw "SHA256 mismatch for $installer (expected $expected, got $actual)" }
+        Start-Process -FilePath ".\$installer" -ArgumentList '/S' -Wait
+        "C:\Program Files\NASM" | Out-File -FilePath "$env:GITHUB_PATH" -Append
+    - name: install nasm (forks)
+      if: github.repository != 'openssl/openssl'
+      run: |
+        $installer = "nasm-3.01-installer-x64.exe"
+        Invoke-WebRequest -Uri "https://www.nasm.us/pub/nasm/releasebuilds/3.01/win64/$installer" -OutFile $installer
+        Start-Process -FilePath ".\$installer" -ArgumentList '/S' -Wait
         "C:\Program Files\NASM" | Out-File -FilePath "$env:GITHUB_PATH" -Append
     - name: install jom
+      if: github.repository == 'openssl/openssl'
       run: |
         mkdir C:\jom
-        Invoke-WebRequest -Uri "https://openssl-library.org/jom-1.1.7.exe" -OutFile C:\jom\jom.exe
+        Invoke-WebRequest -Uri "https://openssl-library.org/ci-deps/jom-1.1.7.exe" -OutFile C:\jom\jom.exe
+        $expected = (Get-Content "$env:GITHUB_WORKSPACE\.github\ci-deps.json" -Raw | ConvertFrom-Json).'jom-1.1.7.exe'
+        $actual = (Get-FileHash C:\jom\jom.exe -Algorithm SHA256).Hash
+        if ($actual -ne $expected) { throw "SHA256 mismatch for jom.exe (expected $expected, got $actual)" }
+        "C:\jom" | Out-File -FilePath "$env:GITHUB_PATH" -Append
+    - name: install jom (forks)
+      if: github.repository != 'openssl/openssl'
+      run: |
+        mkdir C:\jom
+        Invoke-WebRequest -Uri "https://download.qt.io/official_releases/jom/jom_1_1_7.zip" -OutFile C:\jom\jom.zip
+        Expand-Archive -Path C:\jom\jom.zip -DestinationPath C:\jom
         "C:\jom" | Out-File -FilePath "$env:GITHUB_PATH" -Append
     - name: prepare the build directory
       run: mkdir _build


### PR DESCRIPTION
Chocolatey-hosted packages for jom and NASM occasionally become unavailable, causing CI failures on Windows builds. Host these tools on our own infrastructure to eliminate this external dependency.

Affected workflows: windows.yml, windows_comp.yml, os-zoo.yml

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Include a clear description of the issue or feature above this comment if not already provided. This should briefly outline the issue or feature being addressed, along with any relevant implementation details. For performance improvements, include benchmark results as well.

Please always add meaningful commit messages.  Commit message titles (the first line of each commit message which should be separated by an empty line from the rest of the message) should be kept to 50-70 characters if possible.  Further details and Fixes #issue number annotations should be placed in the commit message body (i.e, after the empty line).

Pull requests and commits should be self-contained, allowing readers to understand what changed and why without needing to reference related issues or having prior knowledge. Individual commit messages should include all relevant details to ensure future contributors can easily follow the git history. Clearly explain what is changing and why, and feel free to include detailed (long) descriptions when beneficial to understanding.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
